### PR TITLE
Add variable selection for PSM

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,12 +1,13 @@
 from typing import Union
 
-from fastapi import FastAPI, UploadFile, File, HTTPException
+from fastapi import FastAPI, UploadFile, File, HTTPException, Form
 from fastapi.middleware.cors import CORSMiddleware
 import pandas as pd
 import os
 import sys
 sys.path.append(os.path.dirname(__file__))  # Ensure import from app directory
 from psm import run_psm
+import json
 
 app = FastAPI()
 
@@ -26,14 +27,21 @@ def read_root():
 @app.post("/api/psm")
 async def psm_api(
     experiment: UploadFile = File(...),
-    control: UploadFile = File(...)
+    control: UploadFile = File(...),
+    columns: str | None = Form(None),
 ):
     exp_df = pd.read_csv(experiment.file)
     ctrl_df = pd.read_csv(control.file)
     if list(exp_df.columns) != list(ctrl_df.columns):
         raise HTTPException(status_code=400, detail="两个文件的表头不一致")
+    selected_cols = None
+    if columns:
+        try:
+            selected_cols = json.loads(columns)
+        except json.JSONDecodeError:
+            raise HTTPException(status_code=400, detail="列信息解析失败")
     try:
-        matched = run_psm(exp_df, ctrl_df)
+        matched = run_psm(exp_df, ctrl_df, selected_cols)
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"匹配失败: {str(e)}")
     # 只返回前100行，防止数据过大

--- a/backend/app/psm.py
+++ b/backend/app/psm.py
@@ -1,38 +1,54 @@
 import pandas as pd
 from sklearn.linear_model import LogisticRegression
 from sklearn.neighbors import NearestNeighbors
-from typing import Tuple
+from typing import List, Optional
 
-def run_psm(exp_df: pd.DataFrame, ctrl_df: pd.DataFrame) -> pd.DataFrame:
-    """
-    exp_df: 实验组DataFrame
-    ctrl_df: 对照组DataFrame
-    返回：与实验组匹配的对照组DataFrame（与实验组行数相同，列相同）
-    """
-    # 检查表头
+def run_psm(
+    exp_df: pd.DataFrame,
+    ctrl_df: pd.DataFrame,
+    columns: Optional[List[str]] = None,
+) -> pd.DataFrame:
+    """根据给定列执行倾向性得分匹配并返回匹配后的对照组数据"""
+
+    # 检查表头一致
     if list(exp_df.columns) != list(ctrl_df.columns):
         raise ValueError("实验组和对照组的表头不一致")
-    # 合并数据，添加treatment列
-    exp = exp_df.copy()
-    ctrl = ctrl_df.copy()
-    exp['treatment'] = 1
-    ctrl['treatment'] = 0
-    data = pd.concat([exp, ctrl], ignore_index=True)
-    # 特征列（全部去除treatment）
-    features = [col for col in data.columns if col != 'treatment']
-    X = data[features]
-    T = data['treatment']
-    # 1. 估计倾向性得分
+
+    # 处理选择的列
+    if columns is not None:
+        for col in columns:
+            if col not in exp_df.columns:
+                raise ValueError(f"选择的列不存在: {col}")
+    else:
+        columns = list(exp_df.columns)
+
+    # 模型数据仅保留选择的列
+    exp_model = exp_df[columns].copy()
+    ctrl_model = ctrl_df[columns].copy()
+    exp_model["treatment"] = 1
+    ctrl_model["treatment"] = 0
+    data = pd.concat([exp_model, ctrl_model], ignore_index=True)
+
+    # 估计倾向性得分
+    X = data[columns]
+    T = data["treatment"]
     model = LogisticRegression(max_iter=1000)
     model.fit(X, T)
-    propensity_scores = model.predict_proba(X)[:, 1]
-    data['propensity_score'] = propensity_scores
-    # 2. 最近邻匹配
-    exp_scores = data[data['treatment'] == 1]['propensity_score'].values.reshape(-1, 1)
-    ctrl_scores = data[data['treatment'] == 0]['propensity_score'].values.reshape(-1, 1)
-    nn = NearestNeighbors(n_neighbors=1, algorithm='auto').fit(ctrl_scores)
-    distances, indices = nn.kneighbors(exp_scores)
-    matched_ctrl_indices = data[data['treatment'] == 0].iloc[indices.flatten()].index
-    matched_ctrl = ctrl.loc[matched_ctrl_indices]
-    # 返回匹配后的对照组
-    return matched_ctrl.reset_index(drop=True) 
+    data["propensity_score"] = model.predict_proba(X)[:, 1]
+
+    # 最近邻匹配
+    exp_scores = data[data["treatment"] == 1]["propensity_score"].values.reshape(
+        -1, 1
+    )
+    ctrl_scores = data[data["treatment"] == 0]["propensity_score"].values.reshape(
+        -1, 1
+    )
+    nn = NearestNeighbors(n_neighbors=1, algorithm="auto").fit(ctrl_scores)
+    _, indices = nn.kneighbors(exp_scores)
+    matched_ctrl_indices = (
+        data[data["treatment"] == 0].iloc[indices.flatten()].index
+    )
+
+    # 返回原始对照组中与实验组匹配的行
+    matched_ctrl = ctrl_df.loc[matched_ctrl_indices]
+    return matched_ctrl.reset_index(drop=True)


### PR DESCRIPTION
## Summary
- allow backend to receive list of columns for PSM
- update PSM algorithm to use selected columns
- add column selection UI on the frontend

## Testing
- `pnpm test` *(fails: vitest not installed)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68486a66520c8325a19422a1c32baeba