### PR TITLE
Add numeric result limit and fix PSM index bug

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,12 +1,13 @@
 from typing import Union
 
-from fastapi import FastAPI, UploadFile, File, HTTPException
+from fastapi import FastAPI, UploadFile, File, HTTPException, Form
 from fastapi.middleware.cors import CORSMiddleware
 import pandas as pd
 import os
 import sys
 sys.path.append(os.path.dirname(__file__))  # Ensure import from app directory
 from psm import run_psm
+import json
 
 app = FastAPI()
 
@@ -26,14 +27,27 @@ def read_root():
 @app.post("/api/psm")
 async def psm_api(
     experiment: UploadFile = File(...),
-    control: UploadFile = File(...)
+    control: UploadFile = File(...),
+    columns: str | None = Form(None),
+    n_results: str | None = Form(None),
 ):
     exp_df = pd.read_csv(experiment.file)
     ctrl_df = pd.read_csv(control.file)
     if list(exp_df.columns) != list(ctrl_df.columns):
         raise HTTPException(status_code=400, detail="两个文件的表头不一致")
+    selected_cols = None
+    if columns:
+        try:
+            selected_cols = json.loads(columns)
+        except json.JSONDecodeError:
+            raise HTTPException(status_code=400, detail="列信息解析失败")
+    limit = None
+    if n_results is not None:
+        if not n_results.isdigit() or int(n_results) <= 0:
+            raise HTTPException(status_code=400, detail="结果数量必须为正整数")
+        limit = int(n_results)
     try:
-        matched = run_psm(exp_df, ctrl_df)
+        matched = run_psm(exp_df, ctrl_df, selected_cols, limit)
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"匹配失败: {str(e)}")
     # 只返回前100行，防止数据过大

--- a/backend/app/psm.py
+++ b/backend/app/psm.py
@@ -1,38 +1,70 @@
 import pandas as pd
 from sklearn.linear_model import LogisticRegression
 from sklearn.neighbors import NearestNeighbors
-from typing import Tuple
+from typing import List, Optional
 
-def run_psm(exp_df: pd.DataFrame, ctrl_df: pd.DataFrame) -> pd.DataFrame:
+
+def run_psm(
+    exp_df: pd.DataFrame,
+    ctrl_df: pd.DataFrame,
+    columns: Optional[List[str]] = None,
+    n_results: Optional[int] = None,
+) -> pd.DataFrame:
+    """根据给定列执行倾向性得分匹配并返回按距离排序后的对照组数据
+
+    Parameters
+    ----------
+    exp_df : DataFrame
+        实验组数据
+    ctrl_df : DataFrame
+        对照组数据
+    columns : List[str] | None
+        用于匹配的列，None 表示使用全部列
+    n_results : int | None
+        返回距离最近的前 n_results 个结果，None 表示返回全部匹配结果
     """
-    exp_df: 实验组DataFrame
-    ctrl_df: 对照组DataFrame
-    返回：与实验组匹配的对照组DataFrame（与实验组行数相同，列相同）
-    """
-    # 检查表头
+
+    # 检查表头一致
     if list(exp_df.columns) != list(ctrl_df.columns):
         raise ValueError("实验组和对照组的表头不一致")
-    # 合并数据，添加treatment列
-    exp = exp_df.copy()
-    ctrl = ctrl_df.copy()
-    exp['treatment'] = 1
-    ctrl['treatment'] = 0
-    data = pd.concat([exp, ctrl], ignore_index=True)
-    # 特征列（全部去除treatment）
-    features = [col for col in data.columns if col != 'treatment']
-    X = data[features]
-    T = data['treatment']
-    # 1. 估计倾向性得分
+
+    # 处理选择的列
+    if columns is not None:
+        for col in columns:
+            if col not in exp_df.columns:
+                raise ValueError(f"选择的列不存在: {col}")
+    else:
+        columns = list(exp_df.columns)
+
+    # 模型数据仅保留选择的列
+    exp_model = exp_df[columns].copy()
+    ctrl_model = ctrl_df[columns].copy()
+    exp_model["treatment"] = 1
+    ctrl_model["treatment"] = 0
+    data = pd.concat([exp_model, ctrl_model], ignore_index=True)
+
+    # 估计倾向性得分
+    X = data[columns]
+    T = data["treatment"]
     model = LogisticRegression(max_iter=1000)
     model.fit(X, T)
-    propensity_scores = model.predict_proba(X)[:, 1]
-    data['propensity_score'] = propensity_scores
-    # 2. 最近邻匹配
-    exp_scores = data[data['treatment'] == 1]['propensity_score'].values.reshape(-1, 1)
-    ctrl_scores = data[data['treatment'] == 0]['propensity_score'].values.reshape(-1, 1)
-    nn = NearestNeighbors(n_neighbors=1, algorithm='auto').fit(ctrl_scores)
+    data["propensity_score"] = model.predict_proba(X)[:, 1]
+
+    # 最近邻匹配
+    exp_scores = data[data["treatment"] == 1]["propensity_score"].values.reshape(
+        -1, 1
+    )
+    ctrl_scores = data[data["treatment"] == 0]["propensity_score"].values.reshape(
+        -1, 1
+    )
+    nn = NearestNeighbors(n_neighbors=1, algorithm="auto").fit(ctrl_scores)
     distances, indices = nn.kneighbors(exp_scores)
-    matched_ctrl_indices = data[data['treatment'] == 0].iloc[indices.flatten()].index
-    matched_ctrl = ctrl.loc[matched_ctrl_indices]
-    # 返回匹配后的对照组
-    return matched_ctrl.reset_index(drop=True) 
+    # 根据匹配结果在原始对照组中取出对应行
+    matched_ctrl = ctrl_df.iloc[indices.flatten()].copy()
+    matched_ctrl["match_distance"] = distances.flatten()
+
+    # 按距离从小到大排序并限制返回数量
+    matched_ctrl = matched_ctrl.sort_values("match_distance")
+    if n_results is not None:
+        matched_ctrl = matched_ctrl.head(int(n_results))
+    return matched_ctrl.drop(columns="match_distance").reset_index(drop=True)

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { createFileRoute } from '@tanstack/react-router';
 // @ts-ignore: papaparse may not have types installed. Run: npm install --save-dev @types/papaparse
 import Papa from 'papaparse';
@@ -30,6 +30,20 @@ function App() {
   const [result, setResult] = useState<{ columns: string[]; data: any[] } | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [selectedCols, setSelectedCols] = useState<string[]>([]);
+  const [resultLimit, setResultLimit] = useState('10');
+
+  useEffect(() => {
+    if (
+      expData.length > 0 &&
+      ctrlData.length > 0 &&
+      JSON.stringify(expData[0]) === JSON.stringify(ctrlData[0])
+    ) {
+      setSelectedCols(expData[0]);
+    } else {
+      setSelectedCols([]);
+    }
+  }, [expData, ctrlData]);
 
   const handleExpChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setError(null);
@@ -56,11 +70,13 @@ function App() {
     expFile && ctrlFile &&
     expData.length > 0 &&
     ctrlData.length > 0 &&
-    JSON.stringify(expData[0]) === JSON.stringify(ctrlData[0]);
+    JSON.stringify(expData[0]) === JSON.stringify(ctrlData[0]) &&
+    selectedCols.length > 0 &&
+    Number(resultLimit) > 0;
 
   const handleMatch = async () => {
     if (!canMatch) {
-      setError('请先上传表头一致的实验组和对照组CSV文件');
+      setError('请先上传表头一致的实验组和对照组CSV文件，并选择匹配变量且填写输出结果数');
       return;
     }
     setError(null);
@@ -70,6 +86,8 @@ function App() {
       const formData = new FormData();
       formData.append('experiment', expFile!);
       formData.append('control', ctrlFile!);
+      formData.append('columns', JSON.stringify(selectedCols));
+      formData.append('n_results', resultLimit);
       const res = await fetch('http://localhost:8000/api/psm', {
         method: 'POST',
         body: formData,
@@ -148,6 +166,39 @@ function App() {
         </div>
         {expData.length > 0 && ctrlData.length > 0 && JSON.stringify(expData[0]) !== JSON.stringify(ctrlData[0]) && (
           <div className="text-red-500 mb-4">两个文件的表头不一致，无法进行匹配</div>
+        )}
+        {canMatch && (
+          <div className="mb-4">
+            <div className="font-semibold mb-2">选择匹配变量</div>
+            <div className="flex flex-wrap gap-4">
+              {expData[0].map((header) => (
+                <label key={header} className="flex items-center gap-1">
+                  <input
+                    type="checkbox"
+                    checked={selectedCols.includes(header)}
+                    onChange={() =>
+                      setSelectedCols((cols) =>
+                        cols.includes(header)
+                          ? cols.filter((c) => c !== header)
+                          : [...cols, header]
+                      )
+                    }
+                  />
+                  {header}
+                </label>
+              ))}
+            </div>
+            <div className="mt-4 flex items-center gap-2">
+              <label className="font-semibold">输出结果数</label>
+              <input
+                type="number"
+                min="1"
+                value={resultLimit}
+                onChange={(e) => setResultLimit(e.target.value)}
+                className="border px-2 py-1 rounded w-24"
+              />
+            </div>
+          </div>
         )}
         {error && <div className="text-red-500 mb-4">{error}</div>}
         <button


### PR DESCRIPTION
## Summary
- support `n_results` input for PSM to limit output size
- fix index handling in PSM so nearest-neighbour matches return correct rows

## Testing
- `pnpm test` *(fails: no package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68486a66520c8325a19422a1c32baeba