### PR TITLE
Add result limit option

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -29,6 +29,7 @@ async def psm_api(
     experiment: UploadFile = File(...),
     control: UploadFile = File(...),
     columns: str | None = Form(None),
+    limit: int = Form(100),
 ):
     exp_df = pd.read_csv(experiment.file)
     ctrl_df = pd.read_csv(control.file)
@@ -44,10 +45,10 @@ async def psm_api(
         matched = run_psm(exp_df, ctrl_df, selected_cols)
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"匹配失败: {str(e)}")
-    # 只返回前100行，防止数据过大
+    limit = max(1, min(limit, len(matched)))
     return {
         "columns": list(matched.columns),
-        "data": matched.head(100).to_dict(orient="records")
+        "data": matched.head(limit).to_dict(orient="records")
     }
 
 @app.get("/items/{item_id}")

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -31,6 +31,7 @@ function App() {
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [selectedCols, setSelectedCols] = useState<string[]>([]);
+  const [resultLimit, setResultLimit] = useState(20);
 
   useEffect(() => {
     if (
@@ -85,6 +86,7 @@ function App() {
       formData.append('experiment', expFile!);
       formData.append('control', ctrlFile!);
       formData.append('columns', JSON.stringify(selectedCols));
+      formData.append('limit', resultLimit.toString());
       const res = await fetch('http://localhost:8000/api/psm', {
         method: 'POST',
         body: formData,
@@ -185,6 +187,16 @@ function App() {
                 </label>
               ))}
             </div>
+            <div className="mt-4">
+              <label className="mr-2 font-semibold">匹配结果个数</label>
+              <input
+                type="number"
+                min="1"
+                className="border px-2 py-1 rounded w-24"
+                value={resultLimit}
+                onChange={(e) => setResultLimit(Number(e.target.value))}
+              />
+            </div>
           </div>
         )}
         {error && <div className="text-red-500 mb-4">{error}</div>}
@@ -198,7 +210,7 @@ function App() {
         {result && (
           <div className="mt-8">
             <div className="flex items-center mb-2">
-              <div className="font-semibold text-lg text-blue-700 mr-4">匹配结果（前20行预览）</div>
+              <div className="font-semibold text-lg text-blue-700 mr-4">匹配结果（前{resultLimit}行预览）</div>
               <button
                 className="ml-auto px-4 py-1 rounded bg-green-500 text-white hover:bg-green-600 text-sm"
                 onClick={handleExport}
@@ -216,7 +228,7 @@ function App() {
                   </tr>
                 </thead>
                 <tbody>
-                  {result.data.slice(0, 20).map((row, i) => (
+                  {result.data.slice(0, resultLimit).map((row, i) => (
                     <tr key={i} className="even:bg-blue-50">
                       {result.columns.map((col, j) => (
                         <td key={j} className="px-3 py-2 border-b text-gray-700">{row[col]}</td>
@@ -225,7 +237,9 @@ function App() {
                   ))}
                 </tbody>
               </table>
-              {result.data.length > 20 && <div className="text-xs text-gray-400 p-2">仅预览前20行</div>}
+              {result.data.length > resultLimit && (
+                <div className="text-xs text-gray-400 p-2">仅预览前{resultLimit}行</div>
+              )}
             </div>
           </div>
         )}


### PR DESCRIPTION
## Summary
- support specifying number of matching results returned from backend
- add numeric input on frontend to control result count

## Testing
- `python -m py_compile backend/app/main.py backend/app/psm.py`
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684872e2ef90832586d8484d533f5fad